### PR TITLE
Remove 4.2 changes from 3.9 stable branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@
 The ranged rubrics advanced grading method is based on the Moodle core Rubrics grading method but 
 adding support for ranged values.
 
+## Branches
+
+| Moodle version   | Branch                                                                                                   |
+|------------------|----------------------------------------------------------------------------------------------------------|
+| Moodle 4.2+      | [MOODLE_402_STABLE](https://github.com/catalyst/moodle-gradingform_rubric_ranges/tree/MOODLE_402_STABLE) |
+| Moodle 3.9 - 4.1 | [MOODLE_39_STABLE](https://github.com/catalyst/moodle-gradingform_rubric_ranges/tree/MOODLE_39_STABLE)   |
+
 # Installation
 
 ## Installing via uploaded ZIP file ##

--- a/lib.php
+++ b/lib.php
@@ -28,11 +28,6 @@ require_once($CFG->dirroot.'/grade/grading/form/lib.php');
 require_once($CFG->dirroot.'/lib/filelib.php');
 require_once($CFG->dirroot.'/grade/grading/form/rubric_ranges/classes/printpdf.php');
 
-use core_external\external_value;
-use core_external\external_single_structure;
-use core_external\external_multiple_structure;
-use core_external\external_format_value;
-
 /** rubric: Used to compare our gradeitem_type against. */
 const RUBRIC_RANGES = 'rubric_ranges';
 

--- a/tests/grades/grader/gradingpanel/external/fetch_test.php
+++ b/tests/grades/grader/gradingpanel/external/fetch_test.php
@@ -42,7 +42,6 @@ use moodle_exception;
  * @copyright 2019 Mathew May <mathew.solutions>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
- * @runTestsInSeparateProcesses
  * @covers \gradingform_rubric_ranges\grades\grader\gradingpanel\external\fetch
  */
 class fetch_test extends advanced_testcase {

--- a/tests/grades/grader/gradingpanel/external/store_test.php
+++ b/tests/grades/grader/gradingpanel/external/store_test.php
@@ -42,7 +42,6 @@ use moodle_exception;
  * @copyright 2019 Mathew May <mathew.solutions>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
- * @runTestsInSeparateProcesses
  * @covers \gradingform_rubric_ranges\grades\grader\gradingpanel\external\store
  */
 class store_test extends advanced_testcase {

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'gradingform_rubric_ranges';
-$plugin->version  = 2024012200;    // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release  = 2024012200;    // Match release exactly to version.
+$plugin->version  = 2024012201;    // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release  = 2024012201;    // Match release exactly to version.
 $plugin->requires = 2020060900;
 $plugin->maturity = MATURITY_STABLE;
-$plugin->supported = [39, 402];  // Available as of Moodle 3.9.0 or later.
+$plugin->supported = [39, 401];  // Available as of Moodle 3.9.0 or later.


### PR DESCRIPTION
This should finally resolve #18 

Reverted the 4.2 compatible changes implemented in https://github.com/catalyst/moodle-gradingform_rubric_ranges/commit/c656be3c805ed3bd9cf748c9a59b997d79a5a64d

Coverage change was already reverted in https://github.com/catalyst/moodle-gradingform_rubric_ranges/commit/dff3aa748655668751737aeb4ad4a5f803affb97

Bumped the version to the last digit to aviod potential upgrade issues from 3.9 up to 4.2 branch.

Updated the Readme with the branch info.

I also created `MOODLE_402_STABLE`, added a rule set to protect stable branches and set `MOODLE_402_STABLE` as a new default branch.