### PR TITLE
Remove hardcoded English word

### DIFF
--- a/lang/en/gradingform_rubric_ranges.php
+++ b/lang/en/gradingform_rubric_ranges.php
@@ -62,6 +62,7 @@ $string['level'] = 'Level {$a->definition}, {$a->score} points.';
 $string['leveldelete'] = 'Delete level {$a}';
 $string['leveldefinition'] = 'Level {$a} definition';
 $string['levelempty'] = 'Click to edit level';
+$string['levelrange'] = '{$a->rangestart} to {$a->rangeend}';
 $string['levelsgroup'] = 'Levels group';
 $string['lockzeropoints'] = 'Calculate grade having a minimum score of the minimum achievable grade for the rubric';
 $string['lockzeropoints_help'] = 'This setting only applies if the sum of the minimum number of points for each criterion is greater than 0. If ticked, the minimum score of the activity will be the minimum achievable grade for the rubric. If unticked, the minimum possible score for the rubric will be mapped to the minimum grade available for the activity (which is 0 unless a scale is used).';

--- a/renderer.php
+++ b/renderer.php
@@ -666,14 +666,29 @@ class gradingform_rubric_ranges_renderer extends plugin_renderer_base {
                 }
 
                 foreach ($levelsonly as $levelkey => $level) {
+                    $a = new stdClass();
                     if ($rangecheck == $levelkey) {
-                        $levels[$level['id']]['score'] = ($sortlevels)
-                        ? '0 to '. $level['score']
-                        : $level['score'].' to 0';
+                        if ($sortlevels) {
+                            $a->rangestart = '0';
+                            $a->rangeend = $level['score'];
+                            $levels[$level['id']]['score'] = get_string('levelrange', 'gradingform_rubric_ranges', $a);
+                        } else {
+                            $a->rangestart = $level['score'];
+                            $a->rangeend = '0';
+                            $levels[$level['id']]['score'] = get_string('levelrange', 'gradingform_rubric_ranges', $a);
+                        }
                     } else {
-                        $levels[$level['id']]['score'] = ($sortlevels)
-                        ? ($levelsonly[$levelkey - 1]['score'] + 1).' to '. $level['score']
-                        : $level['score'].' to '. ($levelsonly[$levelkey + 1]['score'] + 1);
+                        if ($sortlevels) {
+                            $previousScore = $levelsonly[$levelkey - 1]['score'] + 1;
+                            $a->rangestart = $previousScore;
+                            $a->rangeend = $level['score'];
+                            $levels[$level['id']]['score'] = get_string('levelrange', 'gradingform_rubric_ranges', $a);
+                        } else {
+                            $nextScore = $levelsonly[$levelkey + 1]['score'] + 1;
+                            $a->rangestart = $level['score'];
+                            $a->rangeend = $nextScore;
+                            $levels[$level['id']]['score'] = get_string('levelrange', 'gradingform_rubric_ranges', $a);
+                        }
                     }
                 }
                 return $levels;

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'gradingform_rubric_ranges';
-$plugin->version  = 2024020500;    // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release  = 2024020500;    // Match release exactly to version.
+$plugin->version  = 2024040200;    // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release  = 2024040200;    // Match release exactly to version.
 $plugin->requires = 2023042400;    // Requires Moodle 4.2.0 or later.
 $plugin->maturity = MATURITY_STABLE;
 $plugin->supported = [402, 402];


### PR DESCRIPTION
When showing the rubric's point ranges the 'to' word is hardcoded, so there is no way no translate it.

This change just replaces that word with an hyphen as a workaround, because transforming that sentence to a translatable string is not trivial.