### PR TITLE
Handle empty rcid and rlid when loading definition (4.2 branch)

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -357,7 +357,7 @@ class gradingform_rubric_ranges_controller extends gradingform_controller {
                 $this->definition->rubric_criteria[$record->rcid]['levels'] = array();
             }
             // Pick the level data.
-            if (!empty($record->rlid)) {
+            if (!empty($record->rlid) && !empty($record->rcid)) {
                 foreach (array('id', 'score', 'definition', 'definitionformat') as $fieldname) {
                     $value = $record->{'rl'.$fieldname};
                     if ($fieldname == 'score') {
@@ -369,7 +369,9 @@ class gradingform_rubric_ranges_controller extends gradingform_controller {
                     $this->definition->rubric_criteria[$record->rcid]['levels'][$record->rlid][$fieldname] = $value;
                 }
             }
-            $this->definition->rubric_criteria[$record->rcid]['points'] = $maxpoint;
+            if (!empty($record->rcid)) {
+                $this->definition->rubric_criteria[$record->rcid]['points'] = $maxpoint;
+            }
         }
 
         $rs->close();


### PR DESCRIPTION
This is to fix https://github.com/catalyst/moodle-gradingform_rubric_ranges/issues/27 which, as described in https://github.com/catalyst/moodle-gradingform_rubric_ranges/pull/28/files#r1948286424 , occures during definition load when rc and rl relatations have no data