### PR TITLE
Port text wrapping behaviour

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -347,7 +347,7 @@ class gradingform_rubric_ranges_renderer extends plugin_renderer_base {
         // Template for one level within one criterion.
         $tdattributes = array(
             'id' => '{NAME}-criteria-{CRITERION-id}-levels-{LEVEL-id}',
-            'class' => 'level' . $level['class']
+            'class' => 'text-break level' . $level['class']
         );
         if (isset($level['tdwidth'])) {
             $tdattributes['width'] = round($level['tdwidth']).'%';


### PR DESCRIPTION
Resolves https://github.com/catalyst/moodle-gradingform_rubric_ranges/issues/42

This ports one of the changes from [MDL-74812](https://moodle.atlassian.net/browse/MDL-74812):

https://github.com/junpataleta/moodle/compare/b81fb00f25...MDL-74812-master#diff-01454b460749127579b5b7fa4482068ee2a30cdd60f19c6b677a14ce935e110cR235

Before:
<img width="1162" height="569" alt="image" src="https://github.com/user-attachments/assets/e26b096e-67b6-4b23-8454-1a2c27861e32" />

After:
<img width="1162" height="569" alt="image" src="https://github.com/user-attachments/assets/ba7f5f3d-ef19-49fb-b0fc-7dca1cb98e70" />
